### PR TITLE
Add WPF WebView2 TCP relay sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# WPF_TCP_Angular
+# WpfKioskApp
+
+This repository contains a sample WPF (.NET Framework 4.7.2) application that hosts a WebView2 control and communicates with a TCP server. The UI is provided by a local HTML/JavaScript page.
+
+## Projects
+
+- `src/WpfKioskApp` – WPF application source code.
+- `src/WpfKioskApp.sln` – Visual Studio solution file.
+
+## Features
+
+- WebView2 hosting of `index.html`.
+- Persistent TCP client with reconnect logic.
+- Message relay between the TCP connection and the JavaScript frontend.
+- Logging using log4net with rolling log files.
+
+## Building
+
+Open `src/WpfKioskApp.sln` with Visual Studio 2019 or later and restore NuGet packages.
+
+## TODO
+
+- Improve UI and connection status display.
+- Add tests and further error handling.

--- a/src/WpfKioskApp.sln
+++ b/src/WpfKioskApp.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfKioskApp", "WpfKioskApp\WpfKioskApp.csproj", "{8CE56254-6A59-4A63-9D03-7C4221870F8E}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {8CE56254-6A59-4A63-9D03-7C4221870F8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {8CE56254-6A59-4A63-9D03-7C4221870F8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {8CE56254-6A59-4A63-9D03-7C4221870F8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {8CE56254-6A59-4A63-9D03-7C4221870F8E}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/src/WpfKioskApp/App.xaml
+++ b/src/WpfKioskApp/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="WpfKioskApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/WpfKioskApp/App.xaml.cs
+++ b/src/WpfKioskApp/App.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using log4net;
+using log4net.Config;
+using System.IO;
+
+namespace WpfKioskApp
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+        static App()
+        {
+            // Initialize log4net configuration
+            XmlConfigurator.Configure(new FileInfo("logging.config"));
+        }
+    }
+}

--- a/src/WpfKioskApp/MainWindow.xaml
+++ b/src/WpfKioskApp/MainWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="WpfKioskApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Kiosk" Height="450" Width="800">
+    <Grid>
+        <WebView2 x:Name="webView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+    </Grid>
+</Window>

--- a/src/WpfKioskApp/MainWindow.xaml.cs
+++ b/src/WpfKioskApp/MainWindow.xaml.cs
@@ -1,0 +1,88 @@
+using Microsoft.Web.WebView2.Core;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows;
+using log4net;
+
+namespace WpfKioskApp
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(MainWindow));
+        private readonly TcpClientManager _tcpClientManager;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            _tcpClientManager = new TcpClientManager("127.0.0.1", 9000, OnTcpMessageReceived, OnTcpStatusChanged);
+            InitializeAsync();
+        }
+
+        private async void InitializeAsync()
+        {
+            try
+            {
+                string exePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string indexPath = Path.Combine(exePath, "index.html");
+                await webView.EnsureCoreWebView2Async();
+                webView.CoreWebView2.WebMessageReceived += WebMessageReceived;
+                webView.Source = new Uri(indexPath);
+
+                await _tcpClientManager.StartAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Initialization failed", ex);
+            }
+        }
+
+        private void WebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            try
+            {
+                string message = e.TryGetWebMessageAsString();
+                Logger.Info($"Message from frontend: {message}");
+                _tcpClientManager.SendAsync(message);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Error processing message from frontend", ex);
+            }
+        }
+
+        private void OnTcpMessageReceived(string message)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                try
+                {
+                    webView.CoreWebView2?.PostWebMessageAsString(message);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Error sending message to frontend", ex);
+                }
+            });
+        }
+
+        private void OnTcpStatusChanged(string status)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                try
+                {
+                    webView.CoreWebView2?.PostWebMessageAsString($"STATUS:{status}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Error sending status to frontend", ex);
+                }
+            });
+        }
+    }
+}

--- a/src/WpfKioskApp/TcpClientManager.cs
+++ b/src/WpfKioskApp/TcpClientManager.cs
@@ -1,0 +1,107 @@
+using log4net;
+using System;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WpfKioskApp
+{
+    /// <summary>
+    /// Manages TCP connection and message dispatching.
+    /// </summary>
+    public class TcpClientManager
+    {
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(TcpClientManager));
+
+        private readonly string _host;
+        private readonly int _port;
+        private readonly Action<string> _onMessage;
+        private readonly Action<string> _onStatus;
+        private TcpClient _client;
+        private NetworkStream _stream;
+        private CancellationTokenSource _cts;
+
+        public TcpClientManager(string host, int port, Action<string> onMessage, Action<string> onStatus)
+        {
+            _host = host;
+            _port = port;
+            _onMessage = onMessage;
+            _onStatus = onStatus;
+        }
+
+        public async Task StartAsync()
+        {
+            _cts = new CancellationTokenSource();
+            await ConnectAsync();
+        }
+
+        private async Task ConnectAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    _client = new TcpClient();
+                    await _client.ConnectAsync(_host, _port);
+                    _stream = _client.GetStream();
+                    _onStatus?.Invoke("Connected");
+                    Logger.Info("Connected to TCP server");
+                    await ReadLoop(_cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    _onStatus?.Invoke("Disconnected");
+                    Logger.Error("TCP connection error", ex);
+                    await Task.Delay(TimeSpan.FromSeconds(10), _cts.Token); // retry delay
+                }
+            }
+        }
+
+        private async Task ReadLoop(CancellationToken token)
+        {
+            byte[] buffer = new byte[1024];
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    int bytesRead = await _stream.ReadAsync(buffer, 0, buffer.Length, token);
+                    if (bytesRead == 0)
+                    {
+                        throw new Exception("Disconnected");
+                    }
+                    string message = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                    _onMessage?.Invoke(message);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Error reading from TCP", ex);
+                    _stream?.Close();
+                    _client?.Close();
+                    break;
+                }
+            }
+        }
+
+        public async Task SendAsync(string message)
+        {
+            if (_stream == null || !_client.Connected) return;
+            try
+            {
+                byte[] data = Encoding.UTF8.GetBytes(message);
+                await _stream.WriteAsync(data, 0, data.Length);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Error sending to TCP", ex);
+            }
+        }
+
+        public void Stop()
+        {
+            _cts.Cancel();
+            _stream?.Close();
+            _client?.Close();
+        }
+    }
+}

--- a/src/WpfKioskApp/WpfKioskApp.csproj
+++ b/src/WpfKioskApp/WpfKioskApp.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2210.55" />
+    <PackageReference Include="log4net" Version="2.0.15" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="logging.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Content Update="index.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="script.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/WpfKioskApp/index.html
+++ b/src/WpfKioskApp/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Kiosk Frontend</title>
+    <style>
+        body { font-family: Arial; margin:20px; }
+        #log { border: 1px solid #ccc; height: 300px; overflow-y: scroll; padding: 5px; }
+    </style>
+</head>
+<body>
+    <div id="log"></div>
+    <input type="text" id="messageBox" placeholder="Type message" />
+    <button onclick="sendMessage()">Send</button>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/src/WpfKioskApp/logging.config
+++ b/src/WpfKioskApp/logging.config
@@ -1,0 +1,17 @@
+<log4net>
+  <appender name="RollingFile" type="log4net.Appender.RollingFileAppender">
+    <file value="logs/app.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Date" />
+    <datePattern value="yyyyMMdd'.log'" />
+    <staticLogFileName value="false" />
+    <maxSizeRollBackups value="10" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date %-5level %logger - %message%newline" />
+    </layout>
+  </appender>
+  <root>
+    <level value="Info" />
+    <appender-ref ref="RollingFile" />
+  </root>
+</log4net>

--- a/src/WpfKioskApp/script.js
+++ b/src/WpfKioskApp/script.js
@@ -1,0 +1,24 @@
+const logDiv = document.getElementById('log');
+const messageBox = document.getElementById('messageBox');
+
+function appendLog(text) {
+    const p = document.createElement('div');
+    p.textContent = text;
+    logDiv.appendChild(p);
+    logDiv.scrollTop = logDiv.scrollHeight;
+}
+
+function sendMessage() {
+    const text = messageBox.value;
+    if (text) {
+        window.chrome.webview.postMessage(text);
+        appendLog('> ' + text);
+        messageBox.value = '';
+    }
+}
+
+window.chrome.webview.addEventListener('message', event => {
+    appendLog('< ' + event.data);
+});
+
+// TODO: add UI improvements and connection status display


### PR DESCRIPTION
## Summary
- build a WPF application that hosts WebView2
- add TCP client manager with reconnect logic
- relay messages between WebView2 JavaScript and TCP socket
- provide basic HTML/JS frontend
- configure rolling log files via log4net

## Testing
- `dotnet build src/WpfKioskApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a22c428c832c93c76898c1716dab